### PR TITLE
Move locales to system

### DIFF
--- a/move-locales-to-system.sh
+++ b/move-locales-to-system.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -xe
+
+SHARED_LOCALES_DIR=$1
+shift 1
+
+for SOURCE_DIR in $@; do
+    if [ ! -d ${SOURCE_DIR} ]; then
+        echo "Source directory '${SOURCE_DIR}' does not exist"
+        exit 1
+    fi
+
+    pushd "${SOURCE_DIR}"
+
+    for LOCALE_NAME in *; do
+        SOURCE_DIR_FULL=$(readlink -e "${LOCALE_NAME}")
+        TARGET_DIR_FULL=$(readlink -m "${SHARED_LOCALES_DIR}/${LOCALE_NAME}/${SOURCE_DIR_FULL}")
+
+        if [ -d "${TARGET_DIR_FULL}" ]; then
+            echo "Target directory '${TARGET_DIR_FULL}' already exists"
+            exit 1
+        fi
+
+        if [ -d "${SOURCE_DIR_FULL}" ]; then
+            install -d "${TARGET_DIR_FULL}"
+            rm -rf "${TARGET_DIR_FULL}"
+            mv "${SOURCE_DIR_FULL}" "${TARGET_DIR_FULL}"
+            ln -s "${TARGET_DIR_FULL}" "${SOURCE_DIR_FULL}"
+        fi
+    done
+
+    popd
+done
+

--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -125,7 +125,30 @@ modules:
         /app/lib/python3.7/site-packages/kolibri/dist/oidc_provider/locale
         /app/lib/python3.7/site-packages/kolibri/dist/kolibri_exercise_perseus_plugin/locale
         /app/lib/python3.7/site-packages/kolibri/dist/rest_framework/locale
+      - >
+        ./move-locales-to-system.sh /app/share/locale
+        /app/lib/python3.7/site-packages/kolibri/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/mptt/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/django_filters/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/pycountry/locales
+        /app/lib/python3.7/site-packages/kolibri/dist/django/contrib/flatpages/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/django/contrib/admindocs/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/django/contrib/sites/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/django/contrib/sessions/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/django/contrib/gis/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/django/contrib/auth/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/django/contrib/contenttypes/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/django/contrib/postgres/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/django/contrib/redirects/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/django/contrib/humanize/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/django/contrib/admin/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/django/conf/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/oidc_provider/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/kolibri_exercise_perseus_plugin/locale
+        /app/lib/python3.7/site-packages/kolibri/dist/rest_framework/locale
     sources:
       - type: file
         path: cleanup-unused-locales.py
+      - type: file
+        path: move-locales-to-system.sh
 


### PR DESCRIPTION
This change moves bundled Python locales to `/app/share/locale`. Normally, these are stored in separate Python module directories like `/app/lib/python3.7/site-packages/...`, meaning that every locale is always installed regardless of the user's preferences. With this change, all the bundled locales are split into the org.learningequality.Kolibri.Locale package, reducing the installed size in most cases.

Unfortunately, it might cause problems in Kolibri depending on how it detects which languages are available for the user.

flathub#6