### PR TITLE
Optimize content import from extensions

### DIFF
--- a/kolibri-flatpak-utils/content_extensions.py
+++ b/kolibri-flatpak-utils/content_extensions.py
@@ -1,5 +1,5 @@
+import itertools
 import json
-import operator
 import os
 import re
 
@@ -8,33 +8,75 @@ from configparser import ConfigParser
 from kolibri_gnome.globals import KOLIBRI_HOME
 
 CONTENT_EXTENSIONS_DIR = "/app/share/kolibri-content"
-
 CONTENT_EXTENSION_RE = r"^org.learningequality.Kolibri.Content.(?P<name>\w+)$"
 
 
-class KolibriContentChannel(object):
-    def __init__(self, channel_id, node_ids, exclude_node_ids):
-        self.__channel_id = channel_id
-        self.__node_ids = node_ids
-        self.__exclude_node_ids = exclude_node_ids
+class ContentExtensionsList(object):
+    """
+    Keeps track of a list of content extensions, either cached from a file in
+    $KOLIBRI_HOME, or generated from /.flatpak-info. Multiple lists can be
+    compared to detect changes in the environment.
+    """
+
+    CONTENT_EXTENSIONS_STATE_PATH = os.path.join(
+        KOLIBRI_HOME, "content-extensions.json"
+    )
+
+    def __init__(self, extensions=set()):
+        self.__extensions = set(extensions)
 
     @classmethod
-    def from_json(cls, json):
-        return cls(
-            json.get("channel_id"), json.get("node_ids"), json.get("exclude_node_ids")
+    def from_flatpak_info(cls):
+        extensions = set()
+
+        flatpak_info = ConfigParser()
+        flatpak_info.read("/.flatpak-info")
+        app_extensions = flatpak_info.get("Instance", "app-extensions", fallback="")
+        for extension_str in app_extensions.split(";"):
+            extension_ref, extension_commit = extension_str.split("=")
+            content_extension = ContentExtension.from_ref(
+                extension_ref, commit=extension_commit
+            )
+            if content_extension and content_extension.is_valid():
+                extensions.add(content_extension)
+
+        return cls(extensions)
+
+    @classmethod
+    def from_cache(cls):
+        extensions = set()
+
+        try:
+            with open(cls.CONTENT_EXTENSIONS_STATE_PATH, "r") as file:
+                extensions_json = json.load(file)
+        except (OSError, json.JSONDecodeError):
+            pass
+        else:
+            extensions = set(map(ContentExtension.from_json, extensions_json))
+
+        return cls(extensions)
+
+    def write_to_cache(self):
+        with open(self.CONTENT_EXTENSIONS_STATE_PATH, "w") as file:
+            extensions_json = list(map(ContentExtension.to_json, self.__extensions))
+            json.dump(extensions_json, file)
+
+    def get_extension(self, ref):
+        return next(
+            (extension for extension in self.__extensions if extension.ref == ref), None
         )
 
-    @property
-    def channel_id(self):
-        return self.__channel_id
+    def __iter__(self):
+        return iter(self.__extensions)
 
-    @property
-    def node_ids(self):
-        return self.__node_ids
-
-    @property
-    def exclude_node_ids(self):
-        return self.__exclude_node_ids
+    @staticmethod
+    def compare(old, new):
+        changed_extensions = old.__extensions.symmetric_difference(new.__extensions)
+        changed_refs = set(extension.ref for extension in changed_extensions)
+        for ref in changed_refs:
+            old_extension = old.get_extension(ref)
+            new_extension = new.get_extension(ref)
+            yield ContentExtensionCompare(ref, old_extension, new_extension)
 
 
 class ContentExtension(object):
@@ -114,9 +156,23 @@ class ContentExtension(object):
         return self.__content_json
 
     @property
-    def channels(self):
+    def __channels(self):
         channels_json = self.content_json.get("channels", [])
-        return set(map(KolibriContentChannel.from_json, channels_json))
+        return set(map(ContentChannel.from_json, channels_json))
+
+    @property
+    def channel_ids(self):
+        return set(channel.channel_id for channel in self.__channels)
+
+    def get_channel(self, channel_id):
+        return next(
+            (
+                channel
+                for channel in self.__channels
+                if channel.channel_id == channel_id
+            ),
+            None,
+        )
 
     @property
     def base_dir(self):
@@ -131,111 +187,136 @@ class ContentExtension(object):
         return os.path.join(self.content_dir, "content.json")
 
 
-class ContentExtensionsList(object):
-    """
-    Keeps track of a list of content extensions, either cached from a file in
-    $KOLIBIR_HOME, or generated from /.flatpak-info. Multiple lists can be
-    compared to detect changes in the environment.
-    """
-
-    CONTENT_EXTENSIONS_STATE_PATH = os.path.join(
-        KOLIBRI_HOME, "content-extensions.json"
-    )
-
-    def __init__(self, extensions=set()):
-        self.__extensions = set(extensions)
+class ContentChannel(object):
+    def __init__(self, channel_id, include_node_ids, exclude_node_ids):
+        self.__channel_id = channel_id
+        self.__include_node_ids = include_node_ids or []
+        self.__exclude_node_ids = exclude_node_ids or []
 
     @classmethod
-    def from_flatpak_info(cls):
-        extensions = set()
+    def from_json(cls, json):
+        return cls(
+            json.get("channel_id"), json.get("node_ids"), json.get("exclude_node_ids")
+        )
 
-        flatpak_info = ConfigParser()
-        flatpak_info.read("/.flatpak-info")
-        app_extensions = flatpak_info.get("Instance", "app-extensions", fallback="")
-        for extension_str in app_extensions.split(";"):
-            extension_ref, extension_commit = extension_str.split("=")
-            content_extension = ContentExtension.from_ref(
-                extension_ref, commit=extension_commit
-            )
-            if content_extension and content_extension.is_valid():
-                extensions.add(content_extension)
+    @property
+    def channel_id(self):
+        return self.__channel_id
 
-        return cls(extensions)
+    @property
+    def include_node_ids(self):
+        return set(self.__include_node_ids)
 
-    @classmethod
-    def from_cache(cls):
-        extensions = set()
+    @property
+    def exclude_node_ids(self):
+        return set(self.__exclude_node_ids)
 
-        try:
-            with open(cls.CONTENT_EXTENSIONS_STATE_PATH, "r") as file:
-                extensions_json = json.load(file)
-        except (OSError, json.JSONDecodeError):
-            pass
+
+class ContentExtensionCompare(object):
+    def __init__(self, ref, old_extension, new_extension):
+        self.__ref = ref
+        self.__old_extension = old_extension
+        self.__new_extension = new_extension
+
+    @property
+    def ref(self):
+        return self.__ref
+
+    def compare_channels(self):
+        for channel_id in self.__all_channel_ids:
+            old_channel = self.__old_channel(channel_id)
+            new_channel = self.__new_channel(channel_id)
+            yield ContentChannelCompare(channel_id, self.__extension_dir, old_channel, new_channel)
+
+    def __old_channel(self, channel_id):
+        if self.__old_extension:
+            return self.__old_extension.get_channel(channel_id)
         else:
-            extensions = set(map(ContentExtension.from_json, extensions_json))
+            return None
 
-        return cls(extensions)
-
-    def write_to_cache(self):
-        with open(self.CONTENT_EXTENSIONS_STATE_PATH, "w") as file:
-            extensions_json = list(map(ContentExtension.to_json, self.__extensions))
-            json.dump(extensions_json, file)
-
-    @property
-    def content_fallback_dirs(self):
-        return list(map(operator.attrgetter("content_dir"), self.__extensions))
-
-    def diff(self, other):
-        return ContentExtensionsDiff(self, other)
-
-    @staticmethod
-    def removed(old, new):
-        removed_refs = old.__refs.difference(new.__refs)
-        return old.__filter_extensions(removed_refs)
-
-    @staticmethod
-    def added(old, new):
-        added_refs = new.__refs.difference(old.__refs)
-        return new.__filter_extensions(added_refs)
-
-    @staticmethod
-    def updated(old, new):
-        common_refs = old.__refs.intersection(new.__refs)
-        old_extensions = old.__filter_extensions(common_refs)
-        new_extensions = new.__filter_extensions(common_refs)
-        return new_extensions.difference(old_extensions)
+    def __new_channel(self, channel_id):
+        if self.__new_extension:
+            return self.__new_extension.get_channel(channel_id)
+        else:
+            return None
 
     @property
-    def __extensions_dict(self):
-        return dict((extension.ref, extension) for extension in self.__extensions)
+    def __extension_dir(self):
+        if self.__new_extension:
+            return self.__new_extension.base_dir
+        else:
+            return None
 
     @property
-    def __refs(self):
-        return set(map(operator.attrgetter("ref"), self.__extensions))
+    def __all_channel_ids(self):
+        return set(itertools.chain(self.__old_channel_ids, self.__new_channel_ids))
 
-    def __get_extension(self, ref):
-        return self.__extensions_dict.get(ref)
+    @property
+    def __old_channel_ids(self):
+        if self.__old_extension:
+            return self.__old_extension.channel_ids
+        else:
+            return set()
 
-    def __filter_extensions(self, refs):
-        return set(map(self.__get_extension, refs))
+    @property
+    def __new_channel_ids(self):
+        if self.__new_extension:
+            return self.__new_extension.channel_ids
+        else:
+            return set()
 
 
-class ContentExtensionsDiff(object):
-    def __init__(self, old_extensions_list, new_extensions_list):
-        self.__old_extensions_list = old_extensions_list
-        self.__new_extensions_list = new_extensions_list
+class ContentChannelCompare(object):
+    def __init__(self, channel_id, extension_dir, old_channel, new_channel):
+        self.__channel_id = channel_id
+        self.__extension_dir = extension_dir
+        self.__old_channel = old_channel
+        self.__new_channel = new_channel
 
-    def removed(self):
-        return ContentExtensionsList.removed(
-            self.__old_extensions_list, self.__new_extensions_list
-        )
+    @property
+    def channel_id(self):
+        return self.__channel_id
 
+    @property
     def added(self):
-        return ContentExtensionsList.added(
-            self.__old_extensions_list, self.__new_extensions_list
-        )
+        return self.__new_channel and not self.__old_channel
 
-    def updated(self):
-        return ContentExtensionsList.updated(
-            self.__old_extensions_list, self.__new_extensions_list
-        )
+    @property
+    def removed(self):
+        return self.__old_channel and not self.__new_channel
+
+    @property
+    def extension_dir(self):
+        return self.__extension_dir
+
+    @property
+    def old_include_node_ids(self):
+        return self.__old_channel.include_node_ids
+
+    @property
+    def new_include_node_ids(self):
+        return self.__new_channel.include_node_ids
+
+    @property
+    def include_nodes_added(self):
+        return self.new_include_node_ids.difference(self.old_include_node_ids)
+
+    @property
+    def include_nodes_removed(self):
+        return self.old_include_node_ids.difference(self.new_include_node_ids)
+
+    @property
+    def old_exclude_node_ids(self):
+        return self.__old_channel.exclude_node_ids
+
+    @property
+    def new_exclude_node_ids(self):
+        return self.__new_channel.exclude_node_ids
+
+    @property
+    def exclude_nodes_added(self):
+        return self.new_exclude_node_ids.difference(self.old_exclude_node_ids)
+
+    @property
+    def exclude_nodes_removed(self):
+        return self.old_exclude_node_ids.difference(self.new_exclude_node_ids)

--- a/kolibri-flatpak-utils/kolibri_wrapper.py
+++ b/kolibri-flatpak-utils/kolibri_wrapper.py
@@ -6,17 +6,124 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-import datetime
-import operator
 import os
 import subprocess
 import sys
 
-from kolibri_gnome.globals import init_logging
+from kolibri_gnome.globals import KOLIBRI_HOME, init_logging
 
 from .content_extensions import ContentExtensionsList
 
 KOLIBRI = "/app/libexec/kolibri"
+
+
+class KolibriContentOperation(object):
+    def apply(self, run_kolibri_fn):
+        raise NotImplementedError()
+
+    @classmethod
+    def from_channel_compare(cls, channel_compare):
+        if channel_compare.added:
+            logger.info("Channel added: %s", channel_compare.channel_id)
+            yield KolibriContentOperation_ImportChannel(
+                channel_id=channel_compare.channel_id,
+                extension_dir=channel_compare.extension_dir
+            )
+            yield KolibriContentOperation_ImportContent(
+                channel_id=channel_compare.channel_id,
+                extension_dir=channel_compare.extension_dir,
+                include_node_ids=channel_compare.new_include_node_ids,
+                exclude_node_ids=channel_compare.new_exclude_node_ids
+            )
+        elif channel_compare.removed:
+            logger.info("Channel removed: %s", channel_compare.channel_id)
+            yield KolibriContentOperation_RescanContent(
+                channel_id=channel_compare.channel_id, removed=True
+            )
+        elif channel_compare.exclude_nodes_added:
+            # We need to rescan all content in the channel
+            # TODO: Find a way to provide old_exclude_node_ids to
+            #       Kolibri instead of scanning all content.
+            logger.info("Channel update (added exclude_nodes): %s", channel_compare.channel_id)
+            yield KolibriContentOperation_RescanContent(
+                channel_id=channel_compare.channel_id
+            )
+        elif channel_compare.include_nodes_removed:
+            # We need to rescan all content in the channel
+            # TODO: Find a way to provide old_include_node_ids to
+            #       Kolibri instead of scanning all content.
+            logger.info("Channel update (removed include_nodes): %s", channel_compare.channel_id)
+            yield KolibriContentOperation_RescanContent(
+                channel_id=channel_compare.channel_id
+            )
+        else:
+            # Channel content updated, no content removed
+            # We can handle this case efficiently with importcontent
+            logger.info("Channel update: %s", channel_compare.channel_id)
+            yield KolibriContentOperation_ImportChannel(
+                channel_id=channel_compare.channel_id,
+                extension_dir=channel_compare.extension_dir
+            )
+            yield KolibriContentOperation_ImportContent(
+                channel_id=channel_compare.channel_id,
+                extension_dir=channel_compare.extension_dir,
+                include_node_ids=channel_compare.new_include_node_ids,
+                exclude_node_ids=channel_compare.new_exclude_node_ids
+            )
+
+
+class KolibriContentOperation_ImportChannel(KolibriContentOperation):
+    def __init__(self, channel_id, extension_dir):
+        self.__channel_id = channel_id
+        self.__extension_dir = extension_dir
+
+    def apply(self, run_kolibri_fn):
+        return run_kolibri_fn(
+            "manage",
+            "scanforcontent",
+            "--channels={}".format(self.__channel_id),
+            "--skip-annotations"
+        )
+
+
+class KolibriContentOperation_ImportContent(KolibriContentOperation):
+    def __init__(self, channel_id, extension_dir, include_node_ids, exclude_node_ids):
+        self.__channel_id = channel_id
+        self.__extension_dir = extension_dir
+        self.__include_node_ids = include_node_ids
+        self.__exclude_node_ids = exclude_node_ids
+
+    def apply(self, run_kolibri_fn):
+        nodes_args = []
+        if self.__include_node_ids:
+            nodes_args.extend(["--node_ids", ','.join(self.__include_node_ids)])
+        if self.__exclude_node_ids:
+            nodes_args.extend(["--exclude_node_ids", ','.join(self.__exclude_node_ids)])
+        return run_kolibri_fn(
+            "manage",
+            "importcontent",
+            *nodes_args,
+            "disk",
+            self.__channel_id,
+            self.__extension_dir or KOLIBRI_HOME
+        )
+
+
+class KolibriContentOperation_RescanContent(KolibriContentOperation):
+    def __init__(self, channel_id, removed=False):
+        self.__channel_id = channel_id
+        self.__removed = removed
+
+    def apply(self, run_kolibri_fn):
+        args = []
+        if self.__removed:
+            args.append("--channel-import-mode=none")
+        return run_kolibri_fn(
+            "manage",
+            "scanforcontent",
+            "--channels={}".format(self.__channel_id),
+            *args
+        )
 
 
 class Application(object):
@@ -25,92 +132,35 @@ class Application(object):
         self.__active_extensions = ContentExtensionsList.from_flatpak_info()
 
     def run(self):
-        extensions_diff = self.__cached_extensions.diff(self.__active_extensions)
-        process_success = all(
-            [
-                self.__process_removed_extensions(extensions_diff),
-                self.__process_added_extensions(extensions_diff),
-                self.__process_updated_extensions(extensions_diff),
-            ]
+        success = all(
+            operation.apply(self.__run_kolibri) == 0
+            for operation in self.__iter_content_operations()
         )
 
-        if process_success:
+        if success:
             self.__active_extensions.write_to_cache()
 
-        return self.__run_kolibri()
+        args = sys.argv[1:]
+        return self.__run_kolibri(*args)
 
-    def __process_removed_extensions(self, extensions_diff):
-        # For each removed channel, run scanforcontent
-        # TODO: Is there a less expensive way of doing this than scanforcontent?
-        channel_ids = set()
-        for extension in extensions_diff.removed():
-            logging.info("Removed extension: %s", extension.ref)
-            channel_ids.update(
-                map(operator.attrgetter("channel_id"), extension.channels)
-            )
-        return self.__kolibri_scan_content(channel_ids, ["--channel-import-mode=none"])
-
-    def __process_added_extensions(self, extensions_diff):
-        # For each added channel, run scanforcontent
-        # TODO: Instead of scanforcontent, use importcontent with --node_ids and --exclude_node_ids
-        channel_ids = set()
-        for extension in extensions_diff.added():
-            logging.info("Added extension: %s", extension.ref)
-            channel_ids.update(
-                map(operator.attrgetter("channel_id"), extension.channels)
-            )
-        return self.__kolibri_scan_content(channel_ids)
-
-    def __process_updated_extensions(self, extensions_diff):
-        # For each updated channel, run scanforcontent
-        # TODO: Instead of scanforcontent, use importcontent with --node_ids and --exclude_node_ids
-        channel_ids = set()
-        for extension in extensions_diff.updated():
-            logging.info("Updated extension: %s", extension.ref)
-            channel_ids.update(
-                map(operator.attrgetter("channel_id"), extension.channels)
-            )
-        return self.__kolibri_scan_content(channel_ids)
-
-    def __kolibri_scan_content(self, channel_ids, args=[]):
-        if len(channel_ids) == 0:
-            return True
-
-        logger.info(
-            "scanforcontent starting for channels %s: %s",
-            channel_ids,
-            datetime.datetime.today(),
-        )
-
-        try:
-            self.__run_kolibri(
-                [
-                    "manage",
-                    "scanforcontent",
-                    "--channels={}".format(",".join(channel_ids)),
-                    *args,
-                ]
-            )
-        except CalledProcessException as error:
-            logger.warning("scanforcontent failed: %s", datetime.datetime.today())
-            return False
-        else:
-            logger.info("scanforcontent completed: %s", datetime.datetime.today())
-            return True
-
-    def __run_kolibri(self, args=None):
-        if args is None:
-            args = sys.argv[1:]
-        result = subprocess.run([KOLIBRI, *args], env=self.__kolibri_env, check=True)
-        return result.returncode
+    def __iter_content_operations(self):
+        for extension_compare in ContentExtensionsList.compare(
+            self.__cached_extensions, self.__active_extensions
+        ):
+            for channel_compare in extension_compare.compare_channels():
+                yield from KolibriContentOperation.from_channel_compare(channel_compare)
 
     @property
     def __kolibri_env(self):
         kolibri_env = os.environ.copy()
         kolibri_env["KOLIBRI_CONTENT_FALLBACK_DIRS"] = ";".join(
-            self.__active_extensions.content_fallback_dirs
+            extension.content_dir for extension in self.__active_extensions
         )
         return kolibri_env
+
+    def __run_kolibri(self, *args):
+        result = subprocess.run([KOLIBRI, *args], env=self.__kolibri_env, check=True)
+        return result.returncode
 
 
 def main():


### PR DESCRIPTION
This changes the Kolibri wrapper code to use importcontent instead of
scanforcontent when possible, providing a significant performance
improvement when starting Kolibri for the first time with content
extensions installed.